### PR TITLE
Update app name and footer text

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -17,7 +17,7 @@ import {
   ledgerWallet,
 } from '@rainbow-me/rainbowkit/wallets';
 
-const appName = 'Crypto Exchange';
+const appName = 'ElementPay';
 const queryClient = new QueryClient();
 
 // Wallet connectors configuration using connectorsForWallets

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,8 @@ import Providers from './Providers';
 import '../styles/globals.css';
 
 export const metadata = {
-  title: 'Crypto Exchange',
-  description: 'Buy and sell cryptocurrency',
+  title: 'Element Pay',
+  description: 'crypto to local currency and vice versa',
 };
 
 export default function RootLayout({

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -4,7 +4,7 @@ import styles from './Footer.module.css';
 const Footer: React.FC = () => {
   return (
     <footer className={styles.footer}>
-      <p>&copy; 2024 Crypto Exchange. All rights reserved.</p>
+      <p>&copy; 2024 Element Pay by Baseflow. All rights reserved.</p>
     </footer>
   );
 };


### PR DESCRIPTION
This pull request includes rebranding changes throughout the application from "Crypto Exchange" to "Element Pay." The most important changes are in the app name, metadata, and footer text.

Rebranding changes:

* [`src/app/Providers.tsx`](diffhunk://#diff-dd6f1ce0c58e3ba1157a07773e11332a55751b31cba1de446f10b9ccecc771f5L20-R20): Changed the application name from `Crypto Exchange` to `ElementPay`.
* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L6-R7): Updated the metadata title and description to reflect the new branding, changing the title to "Element Pay" and the description to "crypto to local currency and vice versa".
* [`src/components/Footer/Footer.tsx`](diffhunk://#diff-eaddc41bc22d344d709d06ba973003d5cb83c6dd8de442594e5ec35dba0db3fcL7-R7): Updated the footer text to reflect the new branding, changing it to "&copy; 2024 Element Pay by Baseflow. All rights reserved."